### PR TITLE
fixed redundant var ctr0 declaration

### DIFF
--- a/public/crosser.js
+++ b/public/crosser.js
@@ -63,7 +63,7 @@ var moveIdle = true; // boolean, used for player character idle
 
 var gamestate = "startup"; // string variable should only contain 'startup','play','win','lose'
 
-let ctr0 = 0; // container for a counter used by controller.js
+// let ctr0 = 0; // container for a counter used by controller.js
 
 // queue to render things, they'll be drawn in this order so it's important
 // to have the order we want. This order will be handled in preload. To deal

--- a/public/lamigra.js
+++ b/public/lamigra.js
@@ -53,7 +53,7 @@ var sombra2; // sprite container for environment set piece
 var gamestate = "startup"; // variable container should hold string lables "startup", "play", "win", "lose"
 var BUGGY = true; // boolean, debug flag, used for debug feature of P5.Play.JS
 
-let ctr0 = 1; // container for a counter used by controller.js
+// let ctr0 = 1; // container for a counter used by controller.js
 
 
 function preload(){


### PR DESCRIPTION
last commit added a redundant declaration of ctr0 at global scope. this crashed everything. I've commented out the older version and so now it works again