### PR TITLE
deprecated mouse click links with image in 3 html documents

### DIFF
--- a/public/_crosser.html
+++ b/public/_crosser.html
@@ -26,6 +26,9 @@
         <!-- envelope will comprise 3 columns -->
         <div id = "left-column">
           <!-- items for left column will go here -->
+
+          <!-- deprecating mouse click link with image for installation -->
+          <!--
           <a href ="_crosser.html">
           <img src="assets/CrosserButtonAllFrames.gif"
                alt="Click here for Crosser game"
@@ -34,6 +37,8 @@
                height="180"
                border="0">
           </a>
+          -->
+
           <h1>Garden del Rio Grande</h1>
           <p>This garden is about reclaiming spaces, telling our stories, and resisting digital colonialism.</p>
           <p>In this part of the garden you will find a diptych, two videogames — Crosser and La Migra — that form a greater whole. The diptych deals with immigration and its responses across the US/Mexico border at El Paso and Ciudad Juarez</p>
@@ -55,6 +60,9 @@
       </div>
       <div id = "right-column">
           <!-- items for right column will go here -->
+
+          <!-- deprecating mouse click link with image for installation -->
+          <!--
           <a href="_lamigra.html">
           <img src="assets/LaMigraAllFrames.gif"
                alt="Click here for La Migra game"
@@ -63,6 +71,8 @@
                height="180"
                border="0">
           </a>
+          -->
+
           <p>&nbsp;</p>
           <h3>Instructions</h3>
           <img src="assets/InstructionsCrosser.png"
@@ -85,7 +95,7 @@
                </p>
                </-->
 
-               
+
           <!--
               just using a simple button for launching each of these, using
               a form allows us to give a url to go to when clicked

--- a/public/_lamigra.html
+++ b/public/_lamigra.html
@@ -27,6 +27,9 @@
         <!-- envelope will comprise 3 columns -->
         <div id = "left-column">
           <!-- items for left column will go here -->
+
+          <!-- deprecating mouse click link with image for installation -->
+          <!--
           <a href="_crosser.html">
           <img src="assets/CrosserButtonAllFrames.gif"
                alt="Click here for Crosser game"
@@ -35,6 +38,8 @@
                height="180"
                border="0">
           </a>
+          -->
+
           <h1>Garden del Rio Grande</h1>
           <p>This garden is about reclaiming spaces, telling our stories, and resisting digital colonialism.</p>
           <p>In this part of the garden you will find a diptych, two videogames — Crosser and La Migra — that form a greater whole. The diptych deals with immigration and its responses across the US/Mexico border at El Paso and Ciudad Juarez</p>
@@ -57,6 +62,9 @@
         </div>
         <div id = "right-column">
           <!-- items for right column will go here -->
+
+          <!-- deprecating mouse click link with image for installation -->
+          <!--
           <a href="_lamigra.html">
           <img src="assets/LaMigraAllFrames.gif"
                alt="Click here for La Migra game"
@@ -65,6 +73,8 @@
                height="180"
                border="0">
           </a>
+          -->
+          
           <p>&nbsp;</p>
           <h3>Instructions</h3>
           <img src="assets/InstructionsLaMigra.png"

--- a/public/index.html
+++ b/public/index.html
@@ -31,6 +31,9 @@
         <!-- envelope will comprise 3 columns -->
         <div id = "left-column">
           <!-- items for left column will go here -->
+
+          <!-- deprecating mouse click link with image for installation -->
+          <!--
           <a href="_crosser.html">
           <img src="assets/CrosserButtonAllFrames.gif"
                alt="Click here for Crosser game"
@@ -39,6 +42,7 @@
                height="180"
                border="0">
           </a>
+          -->
           <h1>Garden del Rio Grande</h1>
           <p>This garden is about reclaiming spaces, telling our stories, and resisting digital colonialism.</p>
           <p>In this part of the garden you will find a diptych, two videogames — Crosser and La Migra — that form a greater whole. The diptych deals with immigration and its responses across the US/Mexico border at El Paso and Ciudad Juarez</p>
@@ -56,6 +60,9 @@
         </div>
         <div id = "right-column">
           <!-- items for right column will go here -->
+
+          <!-- deprecating mouse click link with image for installation -->
+          <!--
           <a href="_lamigra.html">
           <img src="assets/LaMigraAllFrames.gif"
                alt="Click here for La Migra game"
@@ -64,6 +71,7 @@
                height="180"
                border="0">
           </a>
+          -->
           <h4>Credits</h4>
           <p>Crosser and La Migra are a product of SWEAT, a loose collaborative dedicated to the creation of socially conscious games.</p>
           <p> The members of SWEAT that have contributed to Crosser and La Migra are: <ul><li>Francisco Ortega-Grimaldo, <li>Carmen Escobar, <li>Miguel Tarango, <li>Marco Ortega, <li>Ryan Molloy, <li>Tomás Márquez-Carmona, <li>Scott Leutenegger, <li>Chris GauthierDickey, <li>and Rafael Fajardo.</ul></p>


### PR DESCRIPTION
there were images, clickable buttons, in the left and right columns of the html documents. These depend on the presence of a mouse for mouse clicks. Mice won't be part of the DAM installation and so I've deprecated these bits by commenting them out.