### PR TITLE
commented out iBuffalo SNES specific code in updateStatus(pad); for main.js

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -185,6 +185,7 @@ function updateStatus(pad){ // tested once per frame
    *  USB,2-axis 8-button gamepad (STANDARD GAMEPAD Vendor: 0583 Product: 2060)
    *  need a test to enclose it. Axis defaults are 0.00392 (positive values)
    */
+  /**
    if (pad.id.match(standardID)) { // this matches the id against the controller ID value
        if (pad.axes[0] === -1.00000){print('Buffalo SNES d-pad left pressed');} // SNES d-pad leftward
        if (pad.axes[0] ===  1.00000){print('Buffalo SNES d-pad right pressed');} // SNES d-pad leftward
@@ -229,6 +230,8 @@ function updateStatus(pad){ // tested once per frame
        if (pad.buttons[14].value === 1){ print('Buffalo SNES D-pad left pressed');} // redundant with axes 0 (X-value)
        if (pad.buttons[15].value === 1){ print('Buffalo SNES D-pad right pressed');} // redundant with axes 0 (X-value)
     }
+    */
+    
     /**
      *  This bit is specific to the Exlene SNES style controller,
      *  USB Gamepad (Vendor: 0079 Product: 0011)


### PR DESCRIPTION
we are no longer designing for the iBuffalo SNES controller. It has hardware turbo feature that we cannot control in an installation. We are now designing for a generic NES controller.