### PR TITLE
fixed punctuation error in collision box definition for cacahuates

### DIFF
--- a/public/lamigra.js
+++ b/public/lamigra.js
@@ -738,7 +738,7 @@ function preload() {
     img1 = loadImage('img-lamigra/marialucia-2_10.png');
     maluciadepieles.addAnimation('muerto', img1, img1, img1, img1);
     maluciadepieles.changeAnimation('down');
-    maluciadepieles.setCollider(rectangle,0,0,30,62); // set a collision box two pixels smaller than sprite
+    maluciadepieles.setCollider('rectangle',0,0,30,62); // set a collision box two pixels smaller than sprite
     maluciadepieles.debug = DRAW_COLLIDER; // set the debug flag
     renderQueue.push(maluciadepieles); // add maluciadepieles to renderQueue []
     maluciadepieles.name = 'maluciadepieles';
@@ -773,7 +773,7 @@ function preload() {
     img1 = loadImage('img-lamigra/nita-2_10.png');
     nitamoreno.addAnimation('muerto', img1, img1, img1, img1);
     nitamoreno.changeAnimation('down');
-    nitamoreno.setCollider(rectangle,0,0,30,62); // set a collision box two pixels smaller than sprite
+    nitamoreno.setCollider('rectangle',0,0,30,62); // set a collision box two pixels smaller than sprite
     nitamoreno.debug = DRAW_COLLIDER; // set the debug flag
     renderQueue.push(nitamoreno); // add nitamoreno to renderQueue []
     nitamoreno.name = 'nitamoreno';
@@ -809,7 +809,7 @@ function preload() {
     img1 = loadImage('img-lamigra/lino-2_10.png');
     linodepieles.addAnimation('muerto', img1, img1, img1, img1);
     linodepieles.changeAnimation('down');
-    linodepieles.setCollider(rectangle,0,0,30,62); // set a collision box two pixels smaller than sprite
+    linodepieles.setCollider('rectangle',0,0,30,62); // set a collision box two pixels smaller than sprite
     linodepieles.debug = DRAW_COLLIDER; // set the debug flag
     renderQueue.push(linodepieles);
     linodepieles.name = 'linodepieles';
@@ -844,7 +844,7 @@ function preload() {
     img1 = loadImage('img-lamigra/Carlos-Moreno-3_15.png');
     carlosmoreno.addAnimation('muerto', img1, img1, img1, img1);
     carlosmoreno.changeAnimation('down');
-    carlosmoreno.setCollider(rectangle,0,0,30,62); // set a collision box two pixels smaller than sprite
+    carlosmoreno.setCollider('rectangle',0,0,30,62); // set a collision box two pixels smaller than sprite
     carlosmoreno.debug = DRAW_COLLIDER; // set the debug flag
     renderQueue.push(carlosmoreno); // add carlosmoreno to renderQueue []
     carlosmoreno.name = 'carlosmoreno';
@@ -880,7 +880,7 @@ function preload() {
     img1 = loadImage('img-lamigra/marcia-3_10.png');
     marcia.addAnimation('muerto', img1, img1, img1, img1);
     marcia.changeAnimation('down');
-    marcia.setCollider(rectangle,0,0,30,62); // set a collision box two pixels smaller than sprite
+    marcia.setCollider('rectangle',0,0,30,62); // set a collision box two pixels smaller than sprite
     marcia.debug = DRAW_COLLIDER; // set the debug flag
     renderQueue.push(marcia); // add marcia to renderQueue []
     marcia.name = 'marcia';
@@ -916,7 +916,7 @@ function preload() {
     img1 = loadImage('img-lamigra/patricia-2_10.png');
     patricialamachona.addAnimation('muerto', img1, img1, img1, img1);
     patricialamachona.changeAnimation('down');
-    patricialamachona.setCollider(rectangle,0,0,30,62); // set a collision box two pixels smaller than sprite
+    patricialamachona.setCollider('rectangle',0,0,30,62); // set a collision box two pixels smaller than sprite
     patricialamachona.debug = DRAW_COLLIDER; // set the debug flag
     renderQueue.push(patricialamachona); // add patricialamachona to renderQueue []
     patricialamachona.name = 'patricialamachona';
@@ -952,7 +952,7 @@ function preload() {
     img1 = loadImage('img-lamigra/porcupine_14.png');
     puercoespin.addAnimation('muerto', img1, img1, img1, img1);
     puercoespin.changeAnimation('down');
-    puercoespin.setCollider(rectangle,0,0,30,62); // set a collision box two pixels smaller than sprite
+    puercoespin.setCollider('rectangle',0,0,30,62); // set a collision box two pixels smaller than sprite
     puercoespin.debug = DRAW_COLLIDER; // set the debug flag
     renderQueue.push(puercoespin); // add puercoespin to renderQueue []
     puercoespin.name = 'puercoespin';
@@ -988,7 +988,7 @@ function preload() {
     img1 = loadImage('img-lamigra/X-rodar-3_10-copy-b.png');
     xrodar.addAnimation('muerto', img1, img1, img1, img1); // resolved - image is not transparent
     xrodar.changeAnimation('down');
-    xrodar.setCollider(rectangle,0,0,30,62); // set a collision box two pixels smaller than sprite
+    xrodar.setCollider('rectangle',0,0,30,62); // set a collision box two pixels smaller than sprite
     xrodar.debug = DRAW_COLLIDER; // set the debug flag
     renderQueue.push(xrodar); // add xrodar to renderQueue []
     xrodar.name = 'xrodar';


### PR DESCRIPTION
fixing an error I had introduced. forgot to put quotation marks around 'rectangle' in collision box declaration for sprites.